### PR TITLE
Corrected incorrect locale for UK vine

### DIFF
--- a/scripts/preboot.js
+++ b/scripts/preboot.js
@@ -231,7 +231,7 @@ async function getSettings() {
 			vineCurrency = "USD";
 			break;
 		case "co.uk":
-			vineLocale = "en_GB";
+			vineLocale = "en-GB";
 			vineCurrency = "GBP";
 			break;
 		case "fr":


### PR DESCRIPTION
when passing the en_GB you get the incorrect locale error, updated code to use - instead of _