### PR TITLE
Add language support for Amazon.de

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -56,6 +56,7 @@
 	"content_scripts": [
 		{
 			"css": [
+				"resource/css/tabs.css",
 				"resource/css/grid.css",
 				"resource/css/icon.css",
 				"resource/css/main.css",
@@ -68,6 +69,7 @@
 			"matches": [
 				"*://*.amazon.ca/vine/*",
 				"*://*.amazon.de/vine/*",
+				"*://*.amazon.de/*/vine/*",
 				"*://*.amazon.es/vine/*",
 				"*://*.amazon.fr/vine/*",
 				"*://*.amazon.co.uk/vine/*",
@@ -88,6 +90,7 @@
 			"matches": [
 				"*://*.amazon.ca/vine/*",
 				"*://*.amazon.de/vine/*",
+				"*://*.amazon.de/*/vine/*",
 				"*://*.amazon.es/vine/*",
 				"*://*.amazon.fr/vine/*",
 				"*://*.amazon.co.uk/vine/*",
@@ -103,6 +106,7 @@
 			"matches": [
 				"*://*.amazon.ca/review/create-review*",
 				"*://*.amazon.de/review/create-review*",
+				"*://*.amazon.de/*/review/create-review*",
 				"*://*.amazon.es/review/create-review*",
 				"*://*.amazon.fr/review/create-review*",
 				"*://*.amazon.co.uk/review/create-review*",

--- a/manifest_chrome.json
+++ b/manifest_chrome.json
@@ -49,6 +49,7 @@
 	"content_scripts": [
 		{
 			"css": [
+				"resource/css/tabs.css",
 				"resource/css/grid.css",
 				"resource/css/icon.css",
 				"resource/css/main.css",
@@ -61,6 +62,7 @@
 			"matches": [
 				"*://*.amazon.ca/vine/*",
 				"*://*.amazon.de/vine/*",
+				"*://*.amazon.de/*/vine/*",
 				"*://*.amazon.es/vine/*",
 				"*://*.amazon.fr/vine/*",
 				"*://*.amazon.co.uk/vine/*",
@@ -81,6 +83,7 @@
 			"matches": [
 				"*://*.amazon.ca/vine/*",
 				"*://*.amazon.de/vine/*",
+				"*://*.amazon.de/*/vine/*",
 				"*://*.amazon.es/vine/*",
 				"*://*.amazon.fr/vine/*",
 				"*://*.amazon.co.uk/vine/*",
@@ -96,6 +99,7 @@
 			"matches": [
 				"*://*.amazon.ca/review/create-review*",
 				"*://*.amazon.de/review/create-review*",
+				"*://*.amazon.de/*/review/create-review*",
 				"*://*.amazon.es/review/create-review*",
 				"*://*.amazon.fr/review/create-review*",
 				"*://*.amazon.co.uk/review/create-review*",

--- a/manifest_firefox.json
+++ b/manifest_firefox.json
@@ -55,6 +55,7 @@
 	"content_scripts": [
 		{
 			"css": [
+				"resource/css/tabs.css",
 				"resource/css/grid.css",
 				"resource/css/icon.css",
 				"resource/css/main.css",
@@ -67,6 +68,7 @@
 			"matches": [
 				"*://*.amazon.ca/vine/*",
 				"*://*.amazon.de/vine/*",
+				"*://*.amazon.de/*/vine/*",
 				"*://*.amazon.es/vine/*",
 				"*://*.amazon.fr/vine/*",
 				"*://*.amazon.co.uk/vine/*",
@@ -87,6 +89,7 @@
 			"matches": [
 				"*://*.amazon.ca/vine/*",
 				"*://*.amazon.de/vine/*",
+				"*://*.amazon.de/*/vine/*",
 				"*://*.amazon.es/vine/*",
 				"*://*.amazon.fr/vine/*",
 				"*://*.amazon.co.uk/vine/*",
@@ -102,6 +105,7 @@
 			"matches": [
 				"*://*.amazon.ca/review/create-review*",
 				"*://*.amazon.de/review/create-review*",
+				"*://*.amazon.de/*/review/create-review*",
 				"*://*.amazon.es/review/create-review*",
 				"*://*.amazon.fr/review/create-review*",
 				"*://*.amazon.co.uk/review/create-review*",

--- a/scripts/preboot.js
+++ b/scripts/preboot.js
@@ -216,7 +216,7 @@ async function getSettings() {
 	//Figure out what domain the extension is working on
 	//De-activate the unavailableTab (and the voting system) for all non-.ca domains.
 	let currentUrl = window.location.href;
-	regex = /^.+?amazon\.(.+)\/vine\/.*$/;
+	regex = /^.+?amazon\.([a-z\.]+).*\/vine\/.*$/;
 	arrMatches = currentUrl.match(regex);
 	vineDomain = arrMatches[1];
 	vineCountry = vineDomain.split(".").pop();


### PR DESCRIPTION
This PR adds support for Amazon Germany in different languages

## Why

The current issue is with the way Amazon is formatting the links when a user has selected a preferred language in the Amazon settings.

Instead of 

```regex
https://www.amazon.de/vine/*
```

expected by the extension, these are the URLs:

```regex
https://www.amazon.de/-/en/vine/*
https://www.amazon.de/-/nl/vine/*
```

which are not compatible with the current regex in the country-defining code and in the extension manifest. As a result, VineHelper is just not loaded for such pages until a user manually changes the URL to remove `-/en/` or other language code. Unfortunately, this has to be done on each page, because all the page links will have the same added language code.

## How

### Manifests

Are updated to add matches for `*://*.amazon.de/*/vine/*`

### Country code in `preboot.js`

The regex for country definition is changed from

```regex
^.+?amazon\.(.+)\/vine\/.*$
```

to 

```regex
^.+?amazon\.([a-z\.]+).*\/vine\/.*$
```

that should properly get the country from the domain name + be compatible with any other Amazon with a similar language feature. Without it, even if the extension is loaded, some features won't work, e.g. ETV which is country-dependant