### PR TITLE
feat: brenda announcement queue

### DIFF
--- a/scripts/ScreenNotifier.js
+++ b/scripts/ScreenNotifier.js
@@ -3,11 +3,17 @@
  * */
 class ScreenNotification {
 	/** Constructor
-	 * @var tplUrl URL of the template to use, null=default.
+	 * @var params {
+	 *    id: int, //Unique ID of the notification
+	 *    title: string, //Title of the notification
+	 *    content: string, //Content of the notification
+	 *    lifespan: int, //Time in seconds before the notification is removed. 0 = never
+	 *    sound: string, //relative URL of the sound file to play.
+	 *    template: string, //relative URL of the template file to use
+	 *    title_only: bool, //If true, only the title will be displayed. Default: false
+	 * }
 	 */
-	constructor(tplUrl = null) {
-		if (tplUrl === null) tplUrl = "view/notification_default.html";
-
+	constructor(params) {
 		this.id = 0;
 		this.title = "";
 		this.content = "";
@@ -15,8 +21,13 @@ class ScreenNotification {
 		this.sound = null; //relative URL of the sound file to play.
 		this.template = null; //relative URL of the template file to use
 		this.title_only = false;
+		this.template = "view/notification_default.html";
 
-		this.template = tplUrl;
+		if (typeof params === "object") {
+			for (const key in params) {
+				this[key] = params[key];
+			}
+		}
 	}
 
 	//Render the notification HTML.


### PR DESCRIPTION
Creates an announcement queue so that we can handle queuing up multiple announcements so that if you want to announce items too quickly, we can handle it internally and back off from receiving errors from brenda.

Likewise, we set a ceiling on the maximum items on the queue after talking with Thorvarium on discord so that people do not attempt to literally queue up a full page of items and are somewhat restrictive, so we queue up to 5 items and then if they exceed that we show them a notification.