### PR TITLE
remove toLowerCase for keywords to allow uppercase in regex

### DIFF
--- a/popup/homepage.js
+++ b/popup/homepage.js
@@ -365,7 +365,7 @@ function init() {
 		arr = document
 			.getElementById("generalhighlightKeywords")
 			.value.split(",")
-			.map((item) => item.toLowerCase().trim());
+			.map((item) => item.trim());
 		if (arr.length == 1 && arr[0] == "") arr = [];
 		appSettings.general.highlightKeywords = arr;
 		chrome.storage.local.set({ settings: appSettings });
@@ -375,7 +375,7 @@ function init() {
 		arr = document
 			.getElementById("generalhideKeywords")
 			.value.split(",")
-			.map((item) => item.toLowerCase().trim());
+			.map((item) => item.trim());
 		if (arr.length == 1 && arr[0] == "") arr = [];
 		appSettings.general.hideKeywords = arr;
 		chrome.storage.local.set({ settings: appSettings });


### PR DESCRIPTION
I am removing toLowerCase for keywords to allow using uppercase regexes like \S.