### PR TITLE
Add country-specific category icons

### DIFF
--- a/scripts/preboot.js
+++ b/scripts/preboot.js
@@ -195,9 +195,6 @@ async function getSettings() {
 
 	if (appSettings.thorvarium.ETVModalOnTop) loadStyleSheet("node_modules/vine-styling/desktop/etv-modal-on-top.css");
 
-	if (appSettings.thorvarium.categoriesWithEmojis)
-		loadStyleSheet("node_modules/vine-styling/desktop/categories-with-emojis.css");
-
 	if (appSettings.thorvarium.paginationOnTop)
 		loadStyleSheet("node_modules/vine-styling/desktop/pagination-on-top.css");
 
@@ -221,6 +218,18 @@ async function getSettings() {
 	arrMatches = currentUrl.match(regex);
 	vineDomain = arrMatches[1];
 	vineCountry = vineDomain.split(".").pop();
+
+	// Load the country specific stylesheet
+	if (appSettings.thorvarium.categoriesWithEmojis)
+		// The default stylesheet is for the US
+		var emojiList = "categories-with-emojis";
+		// For all other countries, append the country code to the stylesheet
+		if (vineCountry != "com")
+			emojiList += "-" + vineCountry.toUpperCase();
+
+		loadStyleSheet("node_modules/vine-styling/desktop/" + emojiList + ".css");
+
+	showRuntime("BOOT: Thorvarium country-specific stylesheets injected");
 
 	//Send the country code to the Service Worker
 	browser.runtime.sendMessage({


### PR DESCRIPTION
This PR adds the possibility to load category emojis per country (instead of the default one which is US-only).

As a result, it will immediately become compatible with styles already available in `categories-with-emojis-UK.css` and `categories-with-emojis-FR.css`.

As soon as https://github.com/Thorvarium/vine-styling/pull/19 is accepted, this will also work for Amazon Germany. Other countries can also be added easily by adding them to [Thorvarium/vine-styling](https://github.com/Thorvarium/vine-styling) without a need to change anything here.

P.S. In case the defaults for the US are compatible with any other country, this country will need a separate adjustment. Unfortunately, I cannot check this without access to other Vine programs