### PR TITLE
Pin bookmarks buttons to the vine category buttons

### DIFF
--- a/scripts/bootloader.js
+++ b/scripts/bootloader.js
@@ -230,7 +230,7 @@ async function initInsertBookmarkButton() {
 		prom = await Tpl.loadFile("view/bookmark.html");
 		Tpl.setVar("date", appSettings.general.bookmarkDate);
 		let bookmarkContent = Tpl.render(prom);
-		$("#vvp-items-button-container ~ .vvp-container-right-align").append(bookmarkContent);
+		$("#vvp-items-button-container").append(bookmarkContent);
 		$("button.bookmarknow").on("click", function (event) {
 			//Fetch the current date/time from the server
 			let arrJSON = {


### PR DESCRIPTION
This PR will pin the bookmarks buttons (`now`, `-12 h`, `-24 h`) to the Vine category buttons instead of the search bar.

The current issue is that the buttons are pinned to the search bar (as per the wiki). Unfortunately, not all countries have the `search` feature at all. As a result - there was nothing to pin to (no corresponding element in the page code) and this feature of the extension was not available at all e.g. in Germany). With this small change, the feature should be available for all the users.

![image](https://github.com/FMaz008/VineHelper/assets/6554415/87af3002-4308-42ef-b688-3ba68411378b)
