### PR TITLE
Added logic to specify singular timescales

### DIFF
--- a/scripts/tile.js
+++ b/scripts/tile.js
@@ -271,22 +271,62 @@ function Tile(obj, gridInstance) {
 function timeSince(timenow, date) {
 	var seconds = Math.floor((timenow - date) / 1000);
 	var interval = seconds / 31536000;
+	var numberof = 0
 
-	if (interval > 1) return Math.floor(interval) + " years";
+	if (interval > 1) {
+		numberof = Math.floor(interval);
+		if (numberof == 1) {
+			return numberof + " year";
+		} else {
+			return numberof + " years";
+		}
+	}
 
 	interval = seconds / 2592000;
-	if (interval > 1) return Math.floor(interval) + " months";
+	if (interval > 1) {
+		numberof = Math.floor(interval);
+		if (numberof == 1) {
+			return numberof + " month";
+		} else {
+			return numberof + " months";
+		}
+	}
 
 	interval = seconds / 86400;
-	if (interval > 1) return Math.floor(interval) + " days";
+	if (interval > 1) {
+		numberof = Math.floor(interval);
+		if (numberof == 1) {
+			return numberof + " day";
+		} else {
+			return numberof + " days";
+		}
+	}
 
 	interval = seconds / 3600;
-	if (interval > 1) return Math.floor(interval) + " hrs";
+	if (interval > 1) {
+		numberof = Math.floor(interval);
+		if (numberof == 1) {
+			return numberof + " hour";
+		} else {
+			return numberof + " hrs";
+		}
+	}
 
 	interval = seconds / 60;
-	if (interval > 1) return Math.floor(interval) + " mins";
+	if (interval > 1) {
+		numberof = Math.floor(interval);
+		if (numberof == 1) {
+			return numberof + " min";
+		} else {
+			return numberof + " mins";
+		}
+	}
 
-	return Math.floor(seconds) + " secs";
+	if (Math.floor(seconds) == 1) {
+		return Math.floor(seconds) + " sec";
+	} else {
+		return Math.floor(seconds) + " secs";
+	}
 }
 
 function getTileByAsin(asin) {

--- a/scripts/tile.js
+++ b/scripts/tile.js
@@ -269,65 +269,18 @@ function Tile(obj, gridInstance) {
 }
 
 function timeSince(timenow, date) {
-	var seconds = Math.floor((timenow - date) / 1000);
-	var interval = seconds / 31536000;
-	var numberof = 0
+    var seconds = Math.floor((timenow - date) / 1000);
+    var interval = seconds / 31536000;
+    var numberof = 0;
 
-	if (interval > 1) {
-		numberof = Math.floor(interval);
-		if (numberof == 1) {
-			return numberof + " year";
-		} else {
-			return numberof + " years";
-		}
-	}
-
-	interval = seconds / 2592000;
-	if (interval > 1) {
-		numberof = Math.floor(interval);
-		if (numberof == 1) {
-			return numberof + " month";
-		} else {
-			return numberof + " months";
-		}
-	}
-
-	interval = seconds / 86400;
-	if (interval > 1) {
-		numberof = Math.floor(interval);
-		if (numberof == 1) {
-			return numberof + " day";
-		} else {
-			return numberof + " days";
-		}
-	}
-
-	interval = seconds / 3600;
-	if (interval > 1) {
-		numberof = Math.floor(interval);
-		if (numberof == 1) {
-			return numberof + " hour";
-		} else {
-			return numberof + " hrs";
-		}
-	}
-
-	interval = seconds / 60;
-	if (interval > 1) {
-		numberof = Math.floor(interval);
-		if (numberof == 1) {
-			return numberof + " min";
-		} else {
-			return numberof + " mins";
-		}
-	}
-
-	if (Math.floor(seconds) == 1) {
-		return Math.floor(seconds) + " sec";
-	} else {
-		return Math.floor(seconds) + " secs";
-	}
+    return (interval > 1) ? ((numberof = Math.floor(interval)) + (numberof === 1 ? " year" : " years")) :
+        (interval = seconds / 2592000) > 1 ? ((numberof = Math.floor(interval)) + (numberof === 1 ? " month" : " months")) :
+        (interval = seconds / 86400) > 1 ? ((numberof = Math.floor(interval)) + (numberof === 1 ? " day" : " days")) :
+        (interval = seconds / 3600) > 1 ? ((numberof = Math.floor(interval)) + (numberof === 1 ? " hour" : " hrs")) :
+        (interval = seconds / 60) > 1 ? ((numberof = Math.floor(interval)) + (numberof === 1 ? " min" : " mins")) :
+        (Math.floor(seconds) === 1 ? (Math.floor(seconds) + " sec") : (Math.floor(seconds) + " secs"));
 }
+
 
 function getTileByAsin(asin) {
 	let tile = null;


### PR DESCRIPTION
A little thing that's been bugging me since I started using the extension, it doesn't adapt the time-scale to singular or plural.

Ex:
An item was first seen 2 minutes ago, extension reports "First Seen: 2 mins ago".
An item was first seen 1 minute ago, extension reports "First Seen : 1 mins ago".

I tried to figure out how to wedge that logic into a switch/case block, but it wasn't working in my head. I may still think about this more.