### PR TITLE
Fix: Compare keyword ETV thresholds with ranges

### DIFF
--- a/scripts/service_worker/keywordMatch.js
+++ b/scripts/service_worker/keywordMatch.js
@@ -40,12 +40,16 @@ function keywordMatchReturnFullObject(keywords, title, etv_min = null, etv_max =
 			if (regex.test(title)) {
 				if (word.without == "" || !regex2.test(title)) {
 					if (word.etv_min == "" && word.etv_max == "") {
-						//There is ETV filtering defined, we have a match.
+						//There is no ETV filtering defined, we have a match.
 						return true;
 					} else {
-						//There is an ETV filtering defined, we need to satisfy it
-						if (word.etv_min == "" || (etv_min !== null && etv_min >= parseFloat(word.etv_min))) {
-							if (word.etv_max == "" || (etv_max !== null && etv_max <= parseFloat(word.etv_max))) {
+						//There is an ETV filtering defined, we need to satisfy it.
+						//etv_min and etv_max are the values returned by the server.
+						//word.etv_min and word.etv_max are from the user.
+						//For the user's ETV min, match if any variations match (compare against highest ETV, etv_max.)
+						//For the user's ETV max, match if any variations match (compare against lowest ETV, etv_min.)
+						if (word.etv_min == "" || (etv_max !== null && etv_max >= parseFloat(word.etv_min))) {
+							if (word.etv_max == "" || (etv_min !== null && etv_min <= parseFloat(word.etv_max))) {
 								return true;
 							}
 						}


### PR DESCRIPTION
When an item’s ETV is provided as a range, users expect the keyword "ETV min" to be matched against the product’s highest value (etv_max) and the keyword "ETV max" against the product’s lowest value (etv_min). This commit swaps the comparisons in the filtering logic to meet those expectations.

Fixes #185