### PR TITLE
Replaced special characters so that search doesn't break

### DIFF
--- a/scripts/Grid.js
+++ b/scripts/Grid.js
@@ -18,6 +18,7 @@ var HiddenList = new HiddenListMgr();
 
 import { getAsinFromDom } from "./Tile.js";
 
+import { unescapeHTML } from "./StringHelper.js";
 import { TileSizer } from "./TileSizer.js";
 var tileSizer = new TileSizer();
 
@@ -272,7 +273,11 @@ async function addPinnedTile(asin, queue, title, thumbnail, is_parent_asin, enro
 	}
 	let prom2 = await Tpl.loadFile("view/" + templateFile);
 
-	const truncatedTitle = title.length > 40 ? title.substr(0, 40).split(" ").slice(0, -1).join(" ") : title;
+	let truncatedTitle = title.length > 40 ? title.substr(0, 40).split(" ").slice(0, -1).join(" ") : title;
+
+	// These characters were breaking search, resulting in zero results
+	truncatedTitle = unescapeHTML(unescapeHTML(truncatedTitle)).replace(/[&,±]/g, " ");
+
 	const search_url_slug = encodeURIComponent(truncatedTitle);
 
 	const recommendationType = getRecommendationTypeFromQueue(queue);


### PR DESCRIPTION
Before
![image](https://github.com/user-attachments/assets/5732576f-dcd5-41d4-a33c-2ac2d880b17c)
![image](https://github.com/user-attachments/assets/377740cd-5ffa-4a8c-b0e3-3f6daedd93db)


After
![image](https://github.com/user-attachments/assets/4b1f82ba-0ecf-48da-9fc8-7e1830b61ea6)
![image](https://github.com/user-attachments/assets/7b47a24e-2ca9-4665-b705-e6c9cb36b8c1)
