### PR TITLE
Add a scroll-to-top button

### DIFF
--- a/scripts/NotificationMonitor.js
+++ b/scripts/NotificationMonitor.js
@@ -1495,6 +1495,7 @@ class NotificationMonitor {
 
 	_listeners() {
 		// Add the fix toolbar with the pause button if we scroll past the original pause button
+		const scrollToTopBtn = document.getElementById("scrollToTop-fixed");
 		const originalPauseBtn = document.getElementById("pauseFeed");
 		const fixedPauseBtn = document.getElementById("pauseFeed-fixed");
 		const originalBtnPosition = originalPauseBtn.getBoundingClientRect().top + window.scrollY;
@@ -1506,6 +1507,13 @@ class NotificationMonitor {
 			} else {
 				document.getElementById("fixed-toolbar").style.display = "none";
 			}
+		});
+
+		scrollToTopBtn.addEventListener("click", () => {
+			window.scrollTo({
+				top: 0,
+				behavior: "smooth",
+			});
 		});
 
 		fixedPauseBtn.addEventListener("click", () => {

--- a/view/notification_monitor_header.html
+++ b/view/notification_monitor_header.html
@@ -95,9 +95,14 @@
 	</div>
 	<div style="clear: both"></div>
 
-	<div id="fixed-toolbar" style="position: fixed; top: 10px; right: 10px; display: none; z-index: 1000">
-		<label for="pauseFeed-fixed">
-			<input type="button" name="pauseFeed-fixed" id="pauseFeed-fixed" value="Pause & Buffer Feed" />
-		</label>
+	<div id="fixed-toolbar" style="position: fixed; top: 10px; right: 10px; display: none; z-index: 1000;">
+		<div style="display: flex; gap: 5px;">
+			<label for="pauseFeed-fixed">
+				<input type="button" name="pauseFeed-fixed" id="pauseFeed-fixed" value="Pause & Buffer Feed" />
+			</label>
+			<div for="scrollToTop-fixed">
+				<input type="button" name="scrollToTop-fixed" id="scrollToTop-fixed" value="Top">
+			</div>
+		</div>
 	</div>
 </div>


### PR DESCRIPTION
When controls are scrolled out of view, use the "top" button to smooth-scroll back to the top.

<img width="240" alt="Screenshot 2025-04-26 at 9 46 48 AM" src="https://github.com/user-attachments/assets/4512bc9b-ea9a-4b0b-b344-e1cd90301e21" />
