### PR TITLE
Fix persistent striped background when ETV becomes known in notification monitor

### DIFF
--- a/scripts/notification_monitor/MonitorCore.js
+++ b/scripts/notification_monitor/MonitorCore.js
@@ -210,6 +210,10 @@ class MonitorCore {
 		const zeroETVColor = this._settings.get("notification.monitor.zeroETV.color");
 		const unknownETVColor = this._settings.get("notification.monitor.unknownETV.color");
 
+		// Clear both background properties first to ensure clean state
+		notif.style.background = "";
+		notif.style.backgroundColor = "";
+
 		if (isZeroETV && isHighlighted && !this._settings.get("notification.monitor.highlight.ignore0ETVhighlight")) {
 			const color1 = zeroETVColor;
 			const color2 = highlightColor;
@@ -228,8 +232,6 @@ class MonitorCore {
 			notif.style.backgroundColor = zeroETVColor;
 		} else if (isUnknownETV) {
 			notif.style.backgroundColor = unknownETVColor;
-		} else {
-			notif.style.backgroundColor = "unset";
 		}
 	}
 


### PR DESCRIPTION
## Problem
When an item in the notification monitor has an unknown ETV and matches highlight keywords, it displays a striped background pattern. However, when the ETV becomes known, this striped pattern persists incorrectly.

## Root Cause
The issue occurs because when transitioning from "unknown ETV + highlight" to "known ETV + highlight", the code only sets `backgroundColor` but doesn't clear the existing `background` property that contains the striped pattern. Since `background` is a CSS shorthand that takes precedence over `backgroundColor`, the stripes remain visible.

## Solution
Clear both `background` and `backgroundColor` properties at the start of `_processNotificationHighlight()` to ensure a clean state before applying any new styling. This handles all state transitions properly.

## Changes
- Added two lines to clear both background properties before applying new styles
- Removed the else clause that was attempting to clear styles, since clearing now happens upfront

## Testing
Tested with items that:
1. Start with unknown ETV + highlight keywords (shows striped pattern)
2. Receive an ETV update 
3. Verified the striped pattern is properly removed and only solid highlight color remains