### PR TITLE
Fix race condition where unavailable items don't always show visual state

### DIFF
--- a/scripts/notification_monitor/ItemsMgr.js
+++ b/scripts/notification_monitor/ItemsMgr.js
@@ -171,6 +171,7 @@ class ItemsMgr {
 	 * Store the DOM element reference on the items map
 	 * @param {string} asin - The ASIN of the item
 	 * @param {object} element - The DOM element to store
+	 * @returns {boolean} - Returns true if the item was marked as unavailable
 	 */
 	storeItemDOMElement(asin, element) {
 		if (this.items.has(asin)) {
@@ -178,6 +179,9 @@ class ItemsMgr {
 			item.element = element;
 			item.tile = new Tile(element, null);
 			this.items.set(asin, item);
+
+			// Check if this item was marked as unavailable before its DOM was ready
+			return item.data.unavailable === true;
 		} else {
 			throw new Error(`Item ${asin} not found in items map`);
 		}

--- a/scripts/notification_monitor/NotificationMonitor.js
+++ b/scripts/notification_monitor/NotificationMonitor.js
@@ -569,8 +569,13 @@ class NotificationMonitor extends MonitorCore {
 		});
 
 		// Store a reference to the DOM element
-		this._itemsMgr.storeItemDOMElement(asin, tileDOM); //Store the DOM element
+		const wasMarkedUnavailable = this._itemsMgr.storeItemDOMElement(asin, tileDOM); //Store the DOM element
 		const tile = this._itemsMgr.getItemTile(asin);
+
+		// If the item was marked as unavailable before its DOM was ready, apply the unavailable visual state now
+		if (wasMarkedUnavailable) {
+			this._disableItem(tileDOM);
+		}
 
 		if (this._monitorV3 && this._settings.isPremiumUser(2) && this._settings.get("general.displayVariantButton")) {
 			if (is_parent_asin && itemData.variants) {


### PR DESCRIPTION
## Problem
When an item fails to order and becomes unavailable, the visual state (red banner with "UNAVAILABLE" text and dimmed appearance) doesn't always appear. This is an intermittent issue that only affects some items.

## Root Cause Analysis

### The Race Condition
The issue is caused by a race condition in the notification monitor between:
1. **Item creation**: When a new item appears, its data is stored first, then the DOM element is created asynchronously
2. **Unavailable status**: When an order fails, a WebSocket message marks the item as unavailable

### Why It Only Sometimes Occurs
The bug only manifests when these specific conditions align:
1. A new item appears in the notification monitor
2. User quickly attempts to order it before the DOM is fully initialized
3. The order fails with "unavailable" status
4. The WebSocket "unavailableItem" message arrives **after** `addItemData()` but **before** `storeItemDOMElement()`

### The Timing Window
- `addItemData()` stores the item data structure
- DOM creation happens asynchronously via `await this._tpl.render()`
- `storeItemDOMElement()` links the DOM element to the data
- If the unavailable message arrives during the async DOM creation, `markItemUnavailable()` sets the flag but can't apply visual state (no DOM yet)
- When the DOM is finally ready, nothing checks if the item was marked unavailable

## Solution
This fix ensures the unavailable visual state is applied when the DOM element becomes available:
1. Modified `ItemsMgr.storeItemDOMElement()` to return `true` if the item was previously marked as unavailable
2. Modified `NotificationMonitor` to check this return value and apply the unavailable visual state via `_disableItem()`

## Code Flow
```javascript
// When storing DOM element, check if item was marked unavailable
const wasMarkedUnavailable = this._itemsMgr.storeItemDOMElement(asin, tileDOM);

// If it was marked unavailable before DOM was ready, apply visual state now
if (wasMarkedUnavailable) {
    this._disableItem(tileDOM);
}
```

## Changes
- Modified `scripts/notification_monitor/ItemsMgr.js`: Added return value to `storeItemDOMElement()`
- Modified `scripts/notification_monitor/NotificationMonitor.js`: Check return value and apply unavailable state

## Testing
While this race condition is difficult to reproduce consistently, the fix has been verified by:
1. Code analysis confirming the race condition window exists
2. Ensuring no regression for normal unavailable item handling
3. Confirming the fix only activates when the specific race condition occurs