### PR TITLE
feat: Add option to reveal blurred images on hover

### DIFF
--- a/page/settings_keywords.tpl.html
+++ b/page/settings_keywords.tpl.html
@@ -276,6 +276,16 @@
 		<div class="vh-toolbar-icon vh-icon-premium" style="margin-left: 5px"></div>
 	</legend>
 	<div class="toggle-container">
+		<div class="setting-container premium-feature-2">
+			<label for="general.unblurImageOnHover">
+				<input type="checkbox" name="general.unblurImageOnHover" value="1" />
+				Reveal blurred images on hover
+			</label>
+			<div class="setting-summary">
+				<div class="vh-toolbar-icon vh-icon-question"></div>
+				Temporarily show blurred product images when hovering over them, matching the title behavior.
+			</div>
+		</div>
 		<div class="premium-feature-2">
 			<textarea name="general.blurKeywords"></textarea>
 			<div style="text-align: center; font-weight: bold">

--- a/page/settings_loadsave.js
+++ b/page/settings_loadsave.js
@@ -518,6 +518,7 @@ async function initiateSettings() {
 	manageKeywords("general.highlightKeywords");
 	manageKeywords("general.hideKeywords");
 	manageTextareaCSK("general.blurKeywords");
+	manageCheckboxSetting("general.unblurImageOnHover");
 	initiateTogglers();
 	initiateTestKeywords();
 

--- a/scripts/SettingsMgr.js
+++ b/scripts/SettingsMgr.js
@@ -272,6 +272,7 @@ class SettingsMgr {
 				bookmarkDate: 0,
 				blindLoading: false,
 				blurKeywords: [],
+				unblurImageOnHover: false,
 				country: null,
 				customCSS: "",
 				detailsIcon: true,

--- a/scripts/Tile.js
+++ b/scripts/Tile.js
@@ -431,7 +431,14 @@ class Tile {
 			let match = keywordMatch(Settings.get("general.blurKeywords"), this.getTitle(), null, null);
 			if (match) {
 				logger.add("TILE: The item match the keyword '" + match + "', blur it");
-				this.#tileDOM.querySelector("img")?.classList.add("blur");
+				const img = this.#tileDOM.querySelector("img");
+				if (img) {
+					if (Settings.get("general.unblurImageOnHover")) {
+						img.classList.add("dynamic-blur");
+					} else {
+						img.classList.add("blur");
+					}
+				}
 				this.#tileDOM.querySelector(".vvp-item-product-title-container")?.classList.add("dynamic-blur");
 				this.#tileDOM.dataset.blurredKeyword = escapeHTML(match);
 			}

--- a/scripts/notification_monitor/MonitorCore.js
+++ b/scripts/notification_monitor/MonitorCore.js
@@ -285,7 +285,14 @@ class MonitorCore {
 		}
 
 		//Blur the thumbnail and title
-		notif.querySelector(".vh-img-container>img")?.classList.add("blur");
+		const img = notif.querySelector(".vh-img-container>img");
+		if (img) {
+			if (this._settings.get("general.unblurImageOnHover")) {
+				img.classList.add("dynamic-blur");
+			} else {
+				img.classList.add("blur");
+			}
+		}
 		notif.querySelector(".vvp-item-product-title-container>a")?.classList.add("dynamic-blur");
 	}
 


### PR DESCRIPTION
## Description

This PR adds a new checkbox option in the Keywords tab settings to allow users to reveal blurred images on mouse hover, matching the existing behavior for titles.

## Changes

- Added 'Reveal blurred images on hover' checkbox in the blur keywords section (Keywords tab)
- Added new setting  with default value 
- Updated blur logic in  and  to conditionally apply  class
- Checkbox is only visible for premium users (wrapped in  class)

## Implementation Details

- When enabled, images use the  class which removes blur on hover
- When disabled, images use the standard  class for permanent blur
- The setting auto-saves like other checkbox settings
- No new CSS needed - reuses existing  class
- Follows existing UI patterns and code conventions

## Testing

1. Navigate to Settings > Keywords tab
2. Scroll to 'Blur items matching the following keywords' section
3. Check the 'Reveal blurred images on hover' checkbox
4. Add blur keywords and save
5. Navigate to a page with matching items
6. Verify that hovering over blurred images reveals them
7. Uncheck the option and verify images remain permanently blurred

## Notes

- Remote save/load buttons only sync keywords, not UI preferences (consistent with other sections)
- Page reload required for setting to take effect (standard behavior)

## Screenshot
<img width="389" alt="Screenshot 2025-06-14 at 12 18 21 PM" src="https://github.com/user-attachments/assets/64486786-d8f2-4d48-a111-e2a35629c1af" />

