### PR TITLE
Fix pre-release message always showing

### DIFF
--- a/scripts/DynamicModalHelper.js
+++ b/scripts/DynamicModalHelper.js
@@ -54,7 +54,7 @@ function drawButton(asin, isParent, isPreRelease, recommendationType, recommenda
 	btn.id = "dynamicModalBtn-" + asin;
 	btn.dataset.asin = variantAsin ? variantAsin : asin;
 	btn.dataset.isParentAsin = variantAsin ? false : isParent;
-	btn.dataset.isPreRelease = isPreRelease ? true : false;
+	btn.dataset.isPreRelease = isPreRelease === "true" ? true : false;
 	btn.dataset.recommendationType = recommendationType;
 	btn.dataset.recommendationId = recommendationId;
 


### PR DESCRIPTION
Since the data extracted from the URL is a string, it is necessary to check whether isPreRelease is “true” as a string.
This allows VH to control the pre-release message in the modal as expected.