### PR TITLE
Fix context menu 'Add to highlight keywords' functionality

### DIFF
--- a/scripts/bootloader.js
+++ b/scripts/bootloader.js
@@ -1587,7 +1587,7 @@ async function processMessage(data, sender = null, sendResponse = null) {
 	if (data.action === "showPrompt" && data.word) {
 		showCustomPrompt(data.word, data.list).then((result) => {
 			// Send the word to the background script
-			channel.postMessage({ action: "addWord", word: result.word, list: data.list });
+			chrome.runtime.sendMessage({ action: "addWord", word: result.word, list: data.list });
 		});
 		return true; // Keep the message channel open for the async response
 	}


### PR DESCRIPTION
## Problem
The context menu option 'Add to highlight keywords' was not working. When users right-clicked on selected text and chose this option, the keyword was not being added to the highlight keywords list.

## Root Cause
The bootloader was using the wrong communication channel to send the `addWord` message to the service worker.

**What was happening:**
1. User selects text and right-clicks → 'Add to highlight keywords'
2. Content script shows confirmation dialog
3. When user clicks OK, the code sends message via `channel.postMessage` (BroadcastChannel)
4. Service worker is listening via `chrome.runtime.onMessage`
5. Message never reaches service worker → keyword not saved

**Communication channels in VineHelper:**
- **BroadcastChannel** (`channel.postMessage`): For inter-tab communication (e.g., master/slave coordination)
- **Chrome Runtime API** (`chrome.runtime.sendMessage`): For communication with service worker

## Solution
Changed line 1590 in bootloader.js from:
```javascript
channel.postMessage({ action: "addWord", word: result.word, list: data.list });
```

To:
```javascript
chrome.runtime.sendMessage({ action: "addWord", word: result.word, list: data.list });
```

This ensures the message reaches the service worker which handles the keyword storage.

## Testing
1. Load the extension with this fix
2. Navigate to any Vine page
3. Select some text (e.g., a product name)
4. Right-click and choose 'Add to highlight keywords'
5. Confirm/edit the word in the dialog and click OK
6. Go to Extension Settings → Keywords tab
7. Verify the keyword appears in the highlight keywords list

## Related
- This issue was discovered while investigating service worker errors in PR #234
- The `setWord` action (line 1994) was already correctly using `chrome.runtime.sendMessage`