### PR TITLE
Fix: Restore placeholder tiles after clearing unavailable items

### DIFF
--- a/scripts/notifications-monitor/core/NotificationMonitor.js
+++ b/scripts/notifications-monitor/core/NotificationMonitor.js
@@ -392,6 +392,11 @@ class NotificationMonitor extends MonitorCore {
 		// Use the bulk remove method, letting it decide the optimal approach
 		this.#bulkRemoveItems(unavailableAsins, false);
 		this._noShiftGrid.resetEndPlaceholdersCount();
+
+		// Re-insert placeholder tiles if the feature is enabled
+		if (this._noShiftGrid) {
+			this._noShiftGrid.insertPlaceholderTiles();
+		}
 	}
 
 	/**


### PR DESCRIPTION
This PR fixes an issue where placeholder tiles were being cleared when using the Clear unavailable items button in the notification monitor.

When the Display placeholders to keep items from shifting option is enabled, placeholder tiles are inserted to prevent column movement. However, when clearing unavailable items, these placeholder tiles were also being removed and would not come back until a new item was received.

The issue was that clearUnavailableItems() uses bulkRemoveItems() which replaces the entire grid container. Since placeholder tiles only exist in the DOM and are not tracked in the items map, they were lost during this process.

The fix adds a call to insertPlaceholderTiles() after clearing unavailable items to restore the placeholder tiles, following the same pattern used in other parts of the code where items are removed from the grid.