### PR TITLE
Fix count and placeholder synchronization issues

### DIFF
--- a/docs/COUNT_AND_PLACEHOLDER_FIXES.md
+++ b/docs/COUNT_AND_PLACEHOLDER_FIXES.md
@@ -1,0 +1,131 @@
+# Count and Placeholder Synchronization Fixes
+
+## Overview
+
+This document consolidates all fixes related to count synchronization and placeholder positioning issues in the VineHelper notification monitor.
+
+## Issues Fixed
+
+### 1. New Item Placement Before Placeholders
+
+**Problem**: New items from the server were being placed before placeholder tiles instead of after them.
+
+**Solution**: Modified insertion logic to find the first non-placeholder tile:
+
+```javascript
+// For date descending (default), insert after placeholders
+let insertPosition = this._gridContainer.firstChild;
+while (insertPosition && insertPosition.classList.contains("vh-placeholder-tile")) {
+	insertPosition = insertPosition.nextSibling;
+}
+if (insertPosition) {
+	this._gridContainer.insertBefore(fragment, insertPosition);
+} else {
+	// All children are placeholders or container is empty
+	this._gridContainer.appendChild(fragment);
+}
+```
+
+### 2. Zero ETV Items Not Being Counted
+
+**Problem**: Zero ETV items weren't counted in tab title when filter was set to "Zero ETV or KW match only".
+
+**Root Cause**: Type flags (`typeZeroETV`, `typeHighlight`) were set AFTER `processNotificationFiltering` was called and count was emitted.
+
+**Solution**: Set type flags BEFORE filtering:
+
+```javascript
+// Set type flags BEFORE filtering so visibility is calculated correctly
+if (KWsMatch) {
+	tileDOM.dataset.typeHighlight = 1;
+} else if (parseFloat(etv_min) === 0) {
+	tileDOM.dataset.typeZeroETV = 1;
+}
+
+// Now apply filters with correct type flags
+const isVisible = this.#processNotificationFiltering(tileDOM);
+```
+
+### 3. Count Not Updating After Unpause
+
+**Problem**: Tab title count wasn't updating properly after unpausing feed.
+
+**Root Cause**: During paused fetch, items are added but may not be visible due to filters. The incremental count was incorrect.
+
+**Solution**: Always recount visible items after unpause:
+
+```javascript
+// We need to recount because items added during pause might not have been counted
+const newCount = this._countVisibleItems();
+if (this._visibilityStateManager) {
+	this._visibilityStateManager.setCount(newCount);
+}
+this._updateTabTitle(newCount);
+```
+
+### 4. Truncation Count Issues
+
+**Problem**: Count not updating properly during "Fetch 300" with truncation limit of 100.
+
+**Solution**:
+
+- Always recount after fetch completion
+- Added proper count updates when truncation occurs
+- Ensured VisibilityStateManager is synchronized
+
+## Debug Mode
+
+Enable debug logging to troubleshoot count issues:
+
+```javascript
+window.DEBUG_TAB_TITLE = true;
+```
+
+This logs:
+
+- All tab title updates with count values
+- VisibilityStateManager count changes with stack traces
+- Truncation start/end with item counts
+
+## Test Plan
+
+### Basic Functionality Tests
+
+1. **Zero ETV Counting**: Clear grid, let zero ETV items arrive, verify count
+2. **Placeholder Position**: Verify new items appear before placeholders
+3. **Filter Changes**: Switch filters and verify count updates
+4. **Truncation**: Fetch 300 with limit 100, verify final count is 100
+
+### Edge Cases
+
+1. **Rapid Item Arrival**: Multiple items arriving quickly should all be counted
+2. **Concurrent Operations**: Filter change while fetching should maintain correct count
+3. **Empty Grid**: Placeholders should appear correctly when no items present
+
+### Regression Tests
+
+1. Sort order changes don't break counting
+2. Hide/unhide items updates count
+3. Clear all/clear unavailable updates count
+4. Search filter works with type filters
+
+## Implementation Details
+
+### Files Modified
+
+1. `scripts/notifications-monitor/core/NotificationMonitor.js` - Main fixes
+2. `scripts/notifications-monitor/core/MonitorCore.js` - Debug logging
+3. `scripts/notifications-monitor/services/VisibilityStateManager.js` - Debug logging
+
+### Key Principles
+
+- **Accuracy over performance**: Recount when accuracy is critical
+- **Set flags before filtering**: Ensure visibility calculation is correct
+- **Respect visual hierarchy**: Placeholders always at the end
+- **Debug support**: Comprehensive logging for troubleshooting
+
+## Performance Considerations
+
+- Chose full recount over detecting visibility changes in `processNotificationFiltering`
+- Recounting only happens at specific points (unpause, fetch complete)
+- Avoids continuous visibility checks which are resource-intensive on Safari

--- a/docs/README.md
+++ b/docs/README.md
@@ -103,14 +103,15 @@ Comprehensive tracking of memory leak fixes:
     - Array allocation reductions in hot paths
     - Expected additional 40-50% memory reduction
 
-### [COUNT_PLACEHOLDER_SYNC_FIXES.md](./COUNT_PLACEHOLDER_SYNC_FIXES.md)
+### [COUNT_AND_PLACEHOLDER_FIXES.md](./COUNT_AND_PLACEHOLDER_FIXES.md)
 
-Documentation of count/placeholder synchronization fixes:
+Comprehensive documentation of count and placeholder synchronization fixes:
 
-- Tab title count vs visible tiles mismatch resolution
-- Centralized count management through VisibilityStateManager
-- Placeholder buffer synchronization during pause/unpause cycles
-- Anti-flicker measures using DocumentFragment and requestAnimationFrame
+- New item placement relative to placeholders
+- Zero ETV items counting with filters
+- Tab title count synchronization after unpause/truncation
+- Debug mode for troubleshooting count issues
+- Test plan and implementation details
 
 ### [CSP_FIX.md](./CSP_FIX.md)
 

--- a/scripts/notifications-monitor/core/MonitorCore.js
+++ b/scripts/notifications-monitor/core/MonitorCore.js
@@ -395,7 +395,7 @@ class MonitorCore {
 			document.title = "VHNM (" + itemsCount + ")";
 
 			// Debug logging for truncation issues
-			if (window.DEBUG_TAB_TITLE) {
+			if (typeof window !== "undefined" && window.DEBUG_TAB_TITLE) {
 				console.log(`[TabTitle] Updated to: ${itemsCount}`, {
 					providedCount: count,
 					timestamp: new Date().toISOString(),

--- a/scripts/notifications-monitor/core/MonitorCore.js
+++ b/scripts/notifications-monitor/core/MonitorCore.js
@@ -393,6 +393,14 @@ class MonitorCore {
 
 			// Update the tab title
 			document.title = "VHNM (" + itemsCount + ")";
+
+			// Debug logging for truncation issues
+			if (window.DEBUG_TAB_TITLE) {
+				console.log(`[TabTitle] Updated to: ${itemsCount}`, {
+					providedCount: count,
+					timestamp: new Date().toISOString(),
+				});
+			}
 		}, 100); // 100ms delay for UI updates
 	}
 

--- a/scripts/notifications-monitor/core/NotificationMonitor.js
+++ b/scripts/notifications-monitor/core/NotificationMonitor.js
@@ -535,7 +535,7 @@ class NotificationMonitor extends MonitorCore {
 					);
 
 					// Debug logging for truncation
-					if (window.DEBUG_TAB_TITLE) {
+					if (typeof window !== "undefined" && window.DEBUG_TAB_TITLE) {
 						console.log(`[Truncation] Starting truncation`, {
 							currentSize: this._itemsMgr.items.size,
 							maxLimit: max,
@@ -577,7 +577,7 @@ class NotificationMonitor extends MonitorCore {
 					});
 
 					// Debug logging for truncation completion
-					if (window.DEBUG_TAB_TITLE) {
+					if (typeof window !== "undefined" && window.DEBUG_TAB_TITLE) {
 						console.log(`[Truncation] Completed truncation`, {
 							visibleItemsRemoved: visibleItemsRemovedCount,
 							newSize: this._itemsMgr.items.size,

--- a/scripts/notifications-monitor/services/VisibilityStateManager.js
+++ b/scripts/notifications-monitor/services/VisibilityStateManager.js
@@ -77,6 +77,14 @@ class VisibilityStateManager {
 	 * @private
 	 */
 	#emitCountChanged() {
+		// Debug logging for count changes
+		if (window.DEBUG_TAB_TITLE) {
+			console.log(`[VisibilityStateManager] Count changed to: ${this.#count}`, {
+				timestamp: new Date().toISOString(),
+				stack: new Error().stack.split("\n").slice(2, 5).join("\n"),
+			});
+		}
+
 		this.#hookMgr.hookExecute("visibility:count-changed", {
 			count: this.#count,
 			timestamp: Date.now(),

--- a/scripts/notifications-monitor/services/VisibilityStateManager.js
+++ b/scripts/notifications-monitor/services/VisibilityStateManager.js
@@ -78,7 +78,7 @@ class VisibilityStateManager {
 	 */
 	#emitCountChanged() {
 		// Debug logging for count changes
-		if (window.DEBUG_TAB_TITLE) {
+		if (typeof window !== "undefined" && window.DEBUG_TAB_TITLE) {
 			console.log(`[VisibilityStateManager] Count changed to: ${this.#count}`, {
 				timestamp: new Date().toISOString(),
 				stack: new Error().stack.split("\n").slice(2, 5).join("\n"),


### PR DESCRIPTION
## Summary

This PR fixes critical count synchronization and placeholder positioning issues in the notification monitor.

## Issues Fixed

### 1. Zero ETV Items Not Being Counted
- **Problem**: Zero ETV items weren't counted in tab title when filter was set to "Zero ETV or KW match only"
- **Root Cause**: Type flags (`typeZeroETV`, `typeHighlight`) were set AFTER `processNotificationFiltering` was called
- **Solution**: Set type flags BEFORE filtering to ensure correct visibility calculation

### 2. New Items Placed Before Placeholders
- **Problem**: New items from server were placed before placeholder tiles instead of after them
- **Solution**: Modified insertion logic to find first non-placeholder position and insert there

### 3. Count Not Updating After Unpause/Fetch
- **Problem**: Tab title count wasn't updating properly after unpausing feed or fetch completion
- **Solution**: Always recount visible items instead of trusting potentially stale incremental counts

## Technical Details

### Code Changes
- Modified `addTileInGrid` to set type flags before filtering
- Updated insertion logic for date descending sort to respect placeholder positions
- Changed unpause and fetch completion handlers to recount visible items
- Added debug logging for troubleshooting (`window.DEBUG_TAB_TITLE = true`)

### Files Modified
- `scripts/notifications-monitor/core/NotificationMonitor.js` - Main fixes
- `scripts/notifications-monitor/core/MonitorCore.js` - Debug logging
- `scripts/notifications-monitor/services/VisibilityStateManager.js` - Debug logging

### Documentation
- Created comprehensive `docs/COUNT_AND_PLACEHOLDER_FIXES.md`
- Updated `docs/README.md` to reflect new documentation structure
- Consolidated 4 related docs into single comprehensive document

## Testing

Enable debug mode to verify fixes:
```javascript
window.DEBUG_TAB_TITLE = true
```

Test scenarios:
1. Set filter to "Zero ETV or KW match only"
2. Let zero ETV items arrive - verify count increases
3. Check new items appear before placeholders, not after
4. Pause feed, let items accumulate, unpause - verify count updates
5. Perform "Fetch 300" with truncation limit 100 - verify final count is 100

## Performance Considerations

- Chose full recount approach over detecting visibility changes in `processNotificationFiltering`
- Recounting only happens at specific points (unpause, fetch complete)
- Avoids continuous visibility checks which are resource-intensive on Safari