### PR TITLE
Fix keyword testing feature in settings page

### DIFF
--- a/page/settings_loadsave.js
+++ b/page/settings_loadsave.js
@@ -840,13 +840,12 @@ function testKeyword(key, title) {
 	for (let i = 0; i < lines.length; i++) {
 		const containsObj = lines[i].querySelector(`td input[name="contains"]`);
 		const contains = containsObj.value.trim();
+
+		// For testing, we pass a simple array without __keywordType
+		// The last parameter 'true' enables test mode to suppress warnings
 		if (
-			keywordMatch(
-				Object.assign([{ contains: contains, without: "", etv_min: "", etv_max: "" }], {
-					__keywordType: "test",
-				}),
-				title
-			) != false
+			keywordMatch([{ contains: contains, without: "", etv_min: "", etv_max: "" }], title, null, null, true) !=
+			false
 		) {
 			containsObj.style.background = "lightgreen";
 		} else {
@@ -855,13 +854,11 @@ function testKeyword(key, title) {
 
 		const withoutObj = lines[i].querySelector(`td input[name="without"]`);
 		const without = withoutObj.value.trim();
+
+		// Test the 'without' field as if it were a 'contains' field
 		if (
-			keywordMatch(
-				Object.assign([{ contains: without, without: "", etv_min: "", etv_max: "" }], {
-					__keywordType: "test",
-				}),
-				title
-			) != false
+			keywordMatch([{ contains: without, without: "", etv_min: "", etv_max: "" }], title, null, null, true) !=
+			false
 		) {
 			withoutObj.style.background = "lightgreen";
 		} else {

--- a/scripts/core/utils/KeywordMatch.js
+++ b/scripts/core/utils/KeywordMatch.js
@@ -257,8 +257,16 @@ class KeywordMatcher {
 
 	/**
 	 * Main matching function - returns full keyword object if match found
+	 * @param {boolean} isTestMode - If true, suppresses warnings for unknown keyword types (used for testing unsaved keywords)
 	 */
-	keywordMatchReturnFullObject(keywords, title, etv_min = null, etv_max = null, settingsMgr = null) {
+	keywordMatchReturnFullObject(
+		keywords,
+		title,
+		etv_min = null,
+		etv_max = null,
+		settingsMgr = null,
+		isTestMode = false
+	) {
 		// Handle empty keywords array
 		if (!keywords || keywords.length === 0) {
 			return undefined;
@@ -404,8 +412,8 @@ class KeywordMatcher {
 
 			// We couldn't determine the type, so we can't use our fixed storage
 			// This shouldn't happen in normal operation, but we'll handle it gracefully
-			// Only warn if not in test environment
-			if (typeof process === "undefined" || process.env.NODE_ENV !== "test") {
+			// Only warn if not in test environment and not in test mode
+			if (!isTestMode && (typeof process === "undefined" || process.env.NODE_ENV !== "test")) {
 				console.warn("[KeywordMatcher] Could not determine keyword type, compiling at runtime");
 			}
 
@@ -474,10 +482,11 @@ class KeywordMatcher {
 	 * @param {string} title - Title to match against
 	 * @param {*} etv_min - Minimum ETV value
 	 * @param {*} etv_max - Maximum ETV value
+	 * @param {boolean} isTestMode - If true, suppresses warnings for unknown keyword types
 	 * @returns {string|boolean} The matched keyword string or false if no match
 	 */
-	keywordMatch(keywords, title, etv_min = null, etv_max = null) {
-		const match = this.keywordMatchReturnFullObject(keywords, title, etv_min, etv_max);
+	keywordMatch(keywords, title, etv_min = null, etv_max = null, isTestMode = false) {
+		const match = this.keywordMatchReturnFullObject(keywords, title, etv_min, etv_max, null, isTestMode);
 		if (!match) return false;
 
 		// Return the keyword string for backward compatibility
@@ -610,8 +619,8 @@ function keywordMatchReturnFullObject(keywords, title, etv_min = null, etv_max =
 	return keywordMatcher.keywordMatchReturnFullObject(keywords, title, etv_min, etv_max, settingsMgr);
 }
 
-function keywordMatch(keywords, title, etv_min = null, etv_max = null) {
-	return keywordMatcher.keywordMatch(keywords, title, etv_min, etv_max);
+function keywordMatch(keywords, title, etv_min = null, etv_max = null, isTestMode = false) {
+	return keywordMatcher.keywordMatch(keywords, title, etv_min, etv_max, isTestMode);
 }
 
 function hasAnyEtvConditions(keywords) {


### PR DESCRIPTION
## Problem
The keyword testing feature in the settings page was broken - keywords that should match were not being highlighted with a green background.

## Root Cause
The original code was passing `__keywordType: "test"` to the keywordMatch function. After the keyword optimization changes, KeywordMatch.js only accepts three valid keyword types:
- `general.hideKeywords`
- `general.highlightKeywords`
- `general.blurKeywords`

The invalid "test" type was being rejected, causing keywords to never match.

## Attempted Solutions and Why They Failed

### First Attempt: Remove __keywordType
Simply removing the `__keywordType` property caused the KeywordMatcher to fall back to runtime compilation. While this made matching work, it flooded the console with "Could not determine keyword type" warnings - one for each keyword tested on every keystroke.

### Final Solution: Add isTestMode Parameter
Added an optional `isTestMode` parameter to suppress warnings while still allowing runtime compilation:
- `keywordMatchReturnFullObject(..., isTestMode = false)`
- `keywordMatch(..., isTestMode = false)`

When `isTestMode` is true, the warning is suppressed but keywords are still compiled and matched correctly.

## Changes
- Added `isTestMode` parameter (defaults to false) to KeywordMatcher methods
- Modified `testKeyword()` in settings_loadsave.js to pass `true` for isTestMode
- All existing uses remain backward compatible (default false)

## Result
- Keyword testing now works correctly - matching keywords are highlighted green
- No console warnings during testing
- Maintains all existing functionality
- Backward compatible

## Testing
1. Open the settings page
2. Navigate to keyword settings (highlight or hide)
3. Enter test keywords and a test title
4. Verify matching keywords highlight with green background
5. Verify no console warnings appear
6. Verify saved keywords still work normally throughout the extension