### PR TITLE
Fix duplicate notifications by reverting to ASIN-based IDs

### DIFF
--- a/scripts/vh_service_worker_di.js
+++ b/scripts/vh_service_worker_di.js
@@ -294,12 +294,13 @@ chrome.permissions.contains({ permissions: ["notifications"] }, (result) => {
 });
 
 async function pushNotification(title, item) {
-	const notificationId = `notification_${Date.now()}`;
-	const iconUrl = chrome.runtime.getURL("resource/image/icon-128.png");
-
 	// Handle both object with methods and plain object formats
 	// If item is an Item instance, get the data from getAllInfo()
 	const itemData = item.getAllInfo ? item.getAllInfo() : item;
+
+	// Use ASIN-based notification ID to prevent duplicates
+	const notificationId = `notification_${itemData.asin}`;
+	const iconUrl = chrome.runtime.getURL("resource/image/icon-128.png");
 
 	// Store notification data
 	notificationsData[notificationId] = {


### PR DESCRIPTION
## Fix Duplicate Notification Issue

### Problem
The notification system was creating duplicate notifications for the same item when users performed multiple fetch/reload operations. This was caused by using timestamp-based notification IDs (`notification_${Date.now()}`), which generated a unique ID for each notification even when it was for the same item.

### Solution
Reverted to ASIN-based notification IDs (`notification_${itemData.asin}`) to ensure each unique item (ASIN) only generates one notification, regardless of how many times the item is fetched or reloaded.

### Changes
- Modified `pushNotification` function in `scripts/vh_service_worker_di.js`
- Changed notification ID from `notification_${Date.now()}` to `notification_${itemData.asin}`
- Added comment explaining the use of ASIN-based IDs to prevent duplicates

### Testing Instructions
1. Install the extension with this fix
2. Navigate to Vine items page
3. Perform the following sequence:
   - Fetch new items
   - Note any notifications that appear
   - Reload/fetch again
   - Verify that you don't get duplicate notifications for the same items
4. Click on a notification to verify the click handler still works correctly

### Expected Behavior
- Each unique item (ASIN) should only trigger one notification
- Multiple fetches/reloads should not create duplicate notifications
- Notification click handlers should continue to work as expected

### Notes
This change reverts to the previous behavior that was working correctly before the timestamp-based IDs were introduced.